### PR TITLE
Use asset_path in a .css.erb stylesheet

### DIFF
--- a/vendor/assets/stylesheets/font-awesome.css.erb
+++ b/vendor/assets/stylesheets/font-awesome.css.erb
@@ -23,12 +23,17 @@
     */
 
 @font-face {
-    font-family: 'FontAwesome';
-    src: url('/assets/fontawesome-webfont.eot');
-    src: url('/assets/fontawesome-webfont.eot?#iefix') format('embedded-opentype'), url('/assets/fontawesome-webfont.woff') format('woff'), url('/assets/fontawesome-webfont.ttf') format('truetype'), url('/assets/fontawesome-webfont.svgz#FontAwesomeRegular') format('svg'), url('/assets/fontawesome-webfont.svg#FontAwesomeRegular') format('svg');
-    font-weight: normal;
-    font-style: normal;
+  font-family: 'FontAwesome';
+  src: url('<%= asset_path('fontawesome-webfont.eot') %>');
+  src: url('<%= asset_path('fontawesome-webfont.eot') %>?#iefix') format('embedded-opentype'),
+       url('<%= asset_path('fontawesome-webfont.woff') %>') format('woff'),
+       url('<%= asset_path('fontawesome-webfont.ttf') %>') format('truetype'),
+       url('<%= asset_path('fontawesome-webfont.svgz') %>#FontAwesomeRegular') format('svg'),
+       url('<%= asset_path('fontawesome-webfont.svg') %>#FontAwesomeRegular') format('svg');
+  font-weight: normal;
+  font-style: normal;
 }
+
 /* sprites.less reset */
 [class^="icon-"], [class*=" icon-"] {
     display: inline;


### PR DESCRIPTION
I ran into some problems deploying my rails apps using font-awesome-rails: because of the app being deployed to a sub-uri on the production server, the specified font files could not be found in "/assets/".

@pgib posted a fix in issue #1 which uses the `asset_path` method in the stylesheet. Using a *.css.erb file does not depend on any additional gems but still makes the use of `asset_path` available. That and using  `config.action_controller.relative_url_root = '/yoursuburi'` fixed the issue for me and I suddenly had beautiful icons on my site.

What do you think?
