### PR TITLE
'Font' name conflict

### DIFF
--- a/font-awesome-rails.gemspec
+++ b/font-awesome-rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir["test/**/*"]
   gem.name          = "font-awesome-rails"
   gem.require_paths = ["lib"]
-  gem.version       = Font::Awesome::Rails::VERSION
+  gem.version       = FontAwesome::Rails::VERSION
 
   gem.add_dependency "railties", ">= 3.2", "< 5.0"
 

--- a/lib/font-awesome-rails/engine.rb
+++ b/lib/font-awesome-rails/engine.rb
@@ -1,8 +1,6 @@
-module Font
-  module Awesome
-    module Rails
-      class Engine < ::Rails::Engine
-      end
+module FontAwesome
+  module Rails
+    class Engine < ::Rails::Engine
     end
   end
 end

--- a/lib/font-awesome-rails/version.rb
+++ b/lib/font-awesome-rails/version.rb
@@ -1,7 +1,5 @@
-module Font
-  module Awesome
-    module Rails
-      VERSION = "3.2.1.0"
-    end
+module FontAwesome
+  module Rails
+    VERSION = "3.2.1.0"
   end
 end

--- a/test/font_awesome_rails_test.rb
+++ b/test/font_awesome_rails_test.rb
@@ -4,7 +4,7 @@ class FontAwesomeRailsTest < ActionDispatch::IntegrationTest
   teardown { clean_sprockets_cache }
 
   test "engine is loaded" do
-    assert_equal ::Rails::Engine, Font::Awesome::Rails::Engine.superclass
+    assert_equal ::Rails::Engine, FontAwesome::Rails::Engine.superclass
   end
 
   test "fonts are served" do


### PR DESCRIPTION
Hi,
I have a 'Font' model in my project, this seems to create a conflict with this gems 'Font' module. I would think this could apply to others as well.

Any chance you can change this? For instance, font_awesome used FontAwesome as module name.

Regards
Roger Ertesvag
