### PR TITLE
Fix .svg file url so it includes digest when precompiling assets

### DIFF
--- a/app/assets/stylesheets/font-awesome.css.erb
+++ b/app/assets/stylesheets/font-awesome.css.erb
@@ -28,7 +28,7 @@
 @font-face {
   font-family: 'FontAwesome';
   src: url('<%= font_path('fontawesome-webfont.eot') %>');
-  src: url('<%= font_path('fontawesome-webfont.eot') %>?#iefix') format('embedded-opentype'), url('<%= font_path('fontawesome-webfont.woff') %>') format('woff'), url('<%= font_path('fontawesome-webfont.ttf') %>') format('truetype'), url('<%= font_path('fontawesome-webfont.svg#fontawesomeregular') %>') format('svg');
+  src: url('<%= font_path('fontawesome-webfont.eot') %>?#iefix') format('embedded-opentype'), url('<%= font_path('fontawesome-webfont.woff') %>') format('woff'), url('<%= font_path('fontawesome-webfont.ttf') %>') format('truetype'), url('<%= font_path('fontawesome-webfont.svg') %>#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Fixed issue with `.svg` file path. The `#fontawesomeregular` was appended as part of the `font-path` method param, so the digested URL wasn't being generated when precompiling assets.

Probably fixes the issue people seeing in #38 too.
