### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ fa_icon "camera-retro"
 fa_icon "camera-retro", text: "Take a photo"
 # => <i class="fa fa-camera-retro"></i> Take a photo
 
-fa_icon "quote-left 4x muted", class: "muted pull-left"
+fa_icon "quote-left 4x", class: "muted pull-left"
 # => <i class="fa fa-quote-left fa-4x muted pull-left"></i>
 
 content_tag(:li, fa_icon("check li", text: "Bulleted list item"))


### PR DESCRIPTION
Fix syntax for using helper to mute the text. 
- Note for Bootstrap 3 this has been changed to text-muted
