### PR TITLE
Allow text before an icon in the fa_icon helper method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ fa_stacked_icon "terminal inverse", base: "square", class: "pull-right", text: "
 
 ```
 
+Put text first!
+```ruby
+fa_stacked_icon "camera-retro", text: "Take a photo", text_first: true
+# => Take a photo <i class="fa fa-camera-retro"></i>
+
+fa_stacked_icon "terminal inverse", base: "square", class: "pull-right", text: "Hi!"
+# => <span class="fa-stack">
+# =>   Hi!
+# =>   <i class="fa fa-square fa-stack-2x"></i>
+# =>   <i class="fa fa-terminal fa-inverse fa-stack-1x"></i>
+# => </span>
+
+```
+
 **Note:** In Rails 3.2, make sure font-awesome-rails is outside the bundler asset group
 so that these helpers are automatically loaded in production environments.
 
@@ -123,7 +137,7 @@ with every icon. Prepend the `fa` class to existing icons:
 ```css
   /* FontAwesome 3 Syntax */
   <i class="icon-github"></i>
-  
+
   /* FontAwesome 4 Syntax */
   <i class="fa fa-github"></i>
 ```

--- a/app/helpers/font_awesome/rails/icon_helper.rb
+++ b/app/helpers/font_awesome/rails/icon_helper.rb
@@ -32,8 +32,10 @@ module FontAwesome
         classes.concat Private.icon_names(names)
         classes.concat Array(options.delete(:class))
         text = options.delete(:text)
+        text_first = options.delete(:text_first)
         icon = content_tag(:i, nil, options.merge(:class => classes))
-        Private.icon_join(icon, text)
+
+        Private.icon_join(icon, text, (true if text_first))
       end
 
       # Creates an stack set of icon tags given a base icon name, a main icon
@@ -67,16 +69,20 @@ module FontAwesome
         icons = [base, icon]
         icons.reverse! if options.delete(:reverse)
         text = options.delete(:text)
+        text_first = options.delete(:text_first)
         stacked_icon = content_tag(:span, safe_join(icons), options.merge(:class => classes))
-        Private.icon_join(stacked_icon, text)
+
+        Private.icon_join(stacked_icon, text, (true if text_first))
       end
 
       module Private
         extend ActionView::Helpers::OutputSafetyHelper
 
-        def self.icon_join(icon, text)
+        def self.icon_join(icon, text, reverse)
           return icon if text.blank?
-          safe_join([icon, ERB::Util.html_escape(text)], " ")
+          icon_order = [icon, ERB::Util.html_escape(text)]
+          icon_order.reverse! if reverse
+          safe_join(icon_order, " ")
         end
 
         def self.icon_names(names = [])


### PR DESCRIPTION
The helper method fa_icon didn't have any options to have the image behind the text instead of in front of it. So I added the ability to specify that the text should show first.
