### PR TITLE
adding 'depend_on_asset' for sprockets

### DIFF
--- a/app/assets/stylesheets/font-awesome.css.erb
+++ b/app/assets/stylesheets/font-awesome.css.erb
@@ -4,6 +4,14 @@
  */
 /* FONT PATH
  * -------------------------- */
+ 
+//= depend_on_asset "fontawesome-webfont.eot" 
+//= depend_on_asset "fontawesome-webfont.woff"
+//= depend_on_asset "fontawesome-webfont.svg"
+//= depend_on_asset "fontawesome-webfont.ttf"
+//= depend_on_asset "fontawesome-webfont.woff"
+
+ 
 @font-face {
   font-family: 'FontAwesome';
   src: url('<%= font_path('fontawesome-webfont.eot') %>');


### PR DESCRIPTION
http://rubydoc.info/gems/sprockets/2.10.1/file/README.md#The_depend_on_asset_Directive

If a dependency is used in an ERB asset that references another asset, it will not be updated when the reference asset is updated. The fix is to use //= depend_on or its cousin //= depend_on_asset however this is easy to forget. See rails/sprockets-rails#95 for more information.

Currently Rails/Sprockets hides this problem, and only surfaces it when the app is deployed with precompilation to production multiple times. We know that you will have this problem if you are referencing assets from within other assets and not declaring them as dependencies.
(text taken from https://github.com/schneems/sprockets_better_errors)

Finished tests in 0.971674s, 26.7579 tests/s, 60.7200 assertions/s.
26 tests, 59 assertions, 0 failures, 0 errors, 0 skips
