### PR TITLE
Add Readme note on deploying to sub-domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,19 @@ with every icon. Prepend the `fa` class to existing icons:
 ```
 
 **Note when deploying to sub-domains**
-It is sometimes the case that deploying a Rails application to a production environment requires the application to be hosted at a sub-domain on the server. This may be the case, for example, if Apache HTTPD or Nginx is being used as a front-end proxy server, with Rails handling only requests that come in to a sub-domain such as `http://myserver.example.com/myrailsapp`. In this case, the FontAwesome gem (and other asset-serving engines) needs to know the sub-domain, otherwise you can experience a problem roughly described as ["my app works fine in development, but fails when
-I deploy it"](https://github.com/bokmann/font-awesome-rails/issues/74). 
+It is sometimes the case that deploying a Rails application to a production
+environment requires the application to be hosted at a sub-domain on the server. 
+This may be the case, for example, if Apache HTTPD or Nginx is being used as a 
+front-end proxy server, with Rails handling only requests that come in to a sub-domain 
+such as `http://myserver.example.com/myrailsapp`. In this case, the 
+FontAwesome gem (and other asset-serving engines) needs to know the sub-domain, 
+otherwise you can experience a problem roughly described as ["my app works 
+fine in development, but fails when I deploy 
+it"](https://github.com/bokmann/font-awesome-rails/issues/74). 
 
-To fix this, set the *relative URL root* for the application. In the environment file for the deployed version of the app, for example `config/environments/production.rb`,
+To fix this, set the *relative URL root* for the application. In the 
+environment file for the deployed version of the app, for example 
+`config/environments/production.rb`,
 set the config option `action_controller.relative_url_root`:
 
     MyApp::Application.configure do
@@ -144,7 +153,8 @@ set the config option `action_controller.relative_url_root`:
       ...
     end
 
-  The default value of this variable is taken from `ENV['RAILS_RELATIVE_URL_ROOT']`, so configuring the environment to define `RAILS_RELATIVE_URL_ROOT` is an alternative strategy.
+The default value of this variable is taken from `ENV['RAILS_RELATIVE_URL_ROOT']`, 
+so configuring the environment to define `RAILS_RELATIVE_URL_ROOT` is an alternative strategy.
 
 ## License
 


### PR DESCRIPTION
As suggested in the issue comments, I've added a quick write-up of the solution to deploying a FontAwesome app to a server's sub-domain.
