### PR TITLE
Reminder: Remove artificial RubyGems restriction after RubyGems 2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: ruby
 cache: bundler
-before_install:
-  - gem update --system 2.1.11
-  - gem --version
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
See https://github.com/bokmann/font-awesome-rails/commit/3ee8d615549b1dc14a0b187dece3ecef0b9309a8

Travis-CI is currently using a version of RubyGems that has a bug in conjunction with Ruby 1.8. 
