### PR TITLE
Add include_font_awesome helper

### DIFF
--- a/app/helpers/font_awesome/rails/icon_helper.rb
+++ b/app/helpers/font_awesome/rails/icon_helper.rb
@@ -1,6 +1,19 @@
 module FontAwesome
   module Rails
     module IconHelper
+      # Include CSS with Font Awesome. It uses local CSS in development
+      # and CDN in production. Place it in <head> section.
+      def include_font_awesome
+        if ::Rails.env.development?
+          stylesheet_link_tag 'font-awesome', media: nil
+        else
+          version = FontAwesome::Rails::VERSION
+          version = version.split('.')[0..2].join('.')
+          stylesheet_link_tag "//netdna.bootstrapcdn.com/font-awesome/" +
+                              "#{ version }/css/font-awesome.css", media: nil
+        end
+      end
+
       # Creates an icon tag given an icon name and possible icon
       # modifiers.
       #

--- a/test/dummy/app/views/pages/icons.html.erb
+++ b/test/dummy/app/views/pages/icons.html.erb
@@ -1,3 +1,5 @@
+<%= include_font_awesome %>
+
 <%= fa_icon "flag" %>
 
 <%= fa_stacked_icon "twitter", :base => "check-empty" %>

--- a/test/font_awesome_rails_test.rb
+++ b/test/font_awesome_rails_test.rb
@@ -52,6 +52,12 @@ class FontAwesomeRailsTest < ActionDispatch::IntegrationTest
     assert_select "span.fa-stack"
   end
 
+  test "helper should include CSS from CDN" do
+    get "/icons"
+    assert_response :success
+    assert_match '<link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet" />', response.body
+  end
+
   private
 
   def clean_sprockets_cache


### PR DESCRIPTION
In [Getting Started docs](http://fontawesome.io/get-started/) Font Awesome suggest CDN method as first. It will load CSS faster, because user may already had it in cache from different site.
