### PR TITLE
Wrap icon text in a span with alignment classes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 
 group :development do
   gem "guard"
-  gem "guard-test"
+  gem "guard-minitest"
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,4 @@
-guard "test" do
+guard :minitest, bundler: true do
   watch(%r{^app/(.+)\.rb$})  { "test" }
   watch(%r{^lib/(.+)\.rb$})  { "test" }
   watch(%r{^test/(.+)\.rb$}) { "test" }

--- a/README.md
+++ b/README.md
@@ -55,16 +55,16 @@ fa_icon "camera-retro"
 # => <i class="fa fa-camera-retro"></i>
 
 fa_icon "camera-retro", text: "Take a photo"
-# => <i class="fa fa-camera-retro"></i> Take a photo
+# => <i class="fa fa-camera-retro"></i><span class="fa-text fa-text-right">Take a photo</span>
 
 fa_icon "chevron-right", text: "Get started", right: true
-# => Get started <i class="fa fa-chevron-right"></i>
+# => <span class="fa-text fa-text-left">Get started</span><i class="fa fa-chevron-right"></i>
 
 fa_icon "quote-left 4x", class: "text-muted pull-left"
 # => <i class="fa fa-quote-left fa-4x text-muted pull-left"></i>
 
 content_tag(:li, fa_icon("check li", text: "Bulleted list item"))
-# => <li><i class="fa fa-check fa-li"></i> Bulleted list item</li>
+# => <li><i class="fa fa-check fa-li"></i><span class="fa-text fa-text-right">Bulleted list item</span></li>
 ```
 
 ```ruby
@@ -78,7 +78,7 @@ fa_stacked_icon "terminal inverse", base: "square", class: "pull-right", text: "
 # => <span class="fa-stack pull-right">
 # =>   <i class="fa fa-square fa-stack-2x"></i>
 # =>   <i class="fa fa-terminal fa-inverse fa-stack-1x"></i>
-# => </span> Hi!
+# => </span><span class="fa-text fa-text-right">Hi!</span>
 
 ```
 

--- a/app/helpers/font_awesome/rails/icon_helper.rb
+++ b/app/helpers/font_awesome/rails/icon_helper.rb
@@ -10,9 +10,9 @@ module FontAwesome
       #   # => <i class="fa fa-camera-retro"></i>
       #
       #   fa_icon "camera-retro", text: "Take a photo"
-      #   # => <i class="fa fa-camera-retro"></i> Take a photo
+      #   # => <i class="fa fa-camera-retro"></i> <span class="fa-text fa-text-right">Take a photo</span>
       #   fa_icon "chevron-right", text: "Get started", right: true
-      #   # => Get started <i class="fa fa-chevron-right"></i>
+      #   # => <span class="fa-text fa-text-left">Get started</span> <i class="fa fa-chevron-right"></i>
       #
       #   fa_icon "camera-retro 2x"
       #   # => <i class="fa fa-camera-retro fa-2x"></i>
@@ -28,7 +28,7 @@ module FontAwesome
       #   # => <i class="fa fa-user" data-id="123"></i>
       #
       #   content_tag(:li, fa_icon("check li", text: "Bulleted list item"))
-      #   # => <li><i class="fa fa-check fa-li"></i> Bulleted list item</li>
+      #   # => <li><i class="fa fa-check fa-li"></i> <span class="fa-text fa-text-right">Bulleted list item</span></li>
       def fa_icon(names = "flag", options = {})
         classes = ["fa"]
         classes.concat Private.icon_names(names)
@@ -58,7 +58,7 @@ module FontAwesome
       #   # => <span class="fa-stack pull-right">
       #   # =>   <i class="fa fa-square fa-stack-2x"></i>
       #   # =>   <i class="fa fa-terminal fa-inverse fa-stack-1x"></i>
-      #   # => </span> Hi!
+      #   # => </span> <span class="fa-text fa-text-right">Hi!</span>
       #
       #   fa_stacked_icon "camera", base: "ban-circle", reverse: true
       #   # => <span class="fa-stack">

--- a/app/helpers/font_awesome/rails/icon_helper.rb
+++ b/app/helpers/font_awesome/rails/icon_helper.rb
@@ -90,7 +90,7 @@ module FontAwesome
           return icon if text.blank?
           elements = [icon, ERB::Util.html_escape(text)]
           elements.reverse! if reverse_order
-          safe_join(elements)
+          safe_join(elements, " ")
         end
 
         def self.icon_names(names = [])

--- a/app/helpers/font_awesome/rails/icon_helper.rb
+++ b/app/helpers/font_awesome/rails/icon_helper.rb
@@ -36,7 +36,7 @@ module FontAwesome
 
         text_alignment = options[:right] ? "left" : "right"
         text = options.delete(:text)
-        text_tag = text ? content_tag(:span, text, class: "fa-text fa-text-#{text_alignment}") : nil
+        text_tag = text ? content_tag(:span, text, :class => "fa-text fa-text-#{text_alignment}") : nil
 
         right_icon = options.delete(:right)
         icon = content_tag(:i, nil, options.merge(:class => classes))
@@ -76,7 +76,7 @@ module FontAwesome
 
         text_alignment = options[:right] ? "left" : "right"
         text = options.delete(:text)
-        text_tag = text ? content_tag(:span, text, class: "fa-text fa-text-#{text_alignment}") : nil
+        text_tag = text ? content_tag(:span, text, :class => "fa-text fa-text-#{text_alignment}") : nil
 
         right_icon = options.delete(:right)
         stacked_icon = content_tag(:span, safe_join(icons), options.merge(:class => classes))

--- a/app/helpers/font_awesome/rails/icon_helper.rb
+++ b/app/helpers/font_awesome/rails/icon_helper.rb
@@ -33,10 +33,14 @@ module FontAwesome
         classes = ["fa"]
         classes.concat Private.icon_names(names)
         classes.concat Array(options.delete(:class))
+
+        text_alignment = options[:right] ? "left" : "right"
         text = options.delete(:text)
+        text_tag = text ? content_tag(:span, text, class: "fa-text fa-text-#{text_alignment}") : nil
+
         right_icon = options.delete(:right)
         icon = content_tag(:i, nil, options.merge(:class => classes))
-        Private.icon_join(icon, text, right_icon)
+        Private.icon_join(icon, text_tag, right_icon)
       end
 
       # Creates an stack set of icon tags given a base icon name, a main icon
@@ -69,10 +73,14 @@ module FontAwesome
         icon = fa_icon(names, options.delete(:icon_options) || {})
         icons = [base, icon]
         icons.reverse! if options.delete(:reverse)
+
+        text_alignment = options[:right] ? "left" : "right"
         text = options.delete(:text)
+        text_tag = text ? content_tag(:span, text, class: "fa-text fa-text-#{text_alignment}") : nil
+
         right_icon = options.delete(:right)
         stacked_icon = content_tag(:span, safe_join(icons), options.merge(:class => classes))
-        Private.icon_join(stacked_icon, text, right_icon)
+        Private.icon_join(stacked_icon, text_tag, right_icon)
       end
 
       module Private
@@ -82,7 +90,7 @@ module FontAwesome
           return icon if text.blank?
           elements = [icon, ERB::Util.html_escape(text)]
           elements.reverse! if reverse_order
-          safe_join(elements, " ")
+          safe_join(elements)
         end
 
         def self.icon_names(names = [])

--- a/test/icon_helper_test.rb
+++ b/test/icon_helper_test.rb
@@ -36,31 +36,31 @@ class FontAwesome::Rails::IconHelperTest < ActionView::TestCase
   test "#fa_icon should incorporate a text suffix" do
     icon = i("fa fa-camera-retro")
     icon_text = text("Take a photo", "fa-text fa-text-right")
-    assert_icon "#{icon}#{icon_text}", "camera-retro", :text => "Take a photo"
+    assert_icon "#{icon} #{icon_text}", "camera-retro", :text => "Take a photo"
   end
 
   test "#fa_icon should be able to put the icon on the right" do
     icon = i("fa fa-chevron-right")
     icon_text = text("Submit", "fa-text fa-text-left")
-    assert_icon "#{icon_text}#{icon}", "chevron-right", :text => "Submit", :right => true
+    assert_icon "#{icon_text} #{icon}", "chevron-right", :text => "Submit", :right => true
   end
 
   test "#fa_icon should html escape text" do
     icon = i("fa fa-camera-retro")
     icon_text = text("&lt;script&gt;&lt;/script&gt;", "fa-text fa-text-right")
-    assert_icon "#{icon}#{icon_text}", "camera-retro", :text => "<script></script>"
+    assert_icon "#{icon} #{icon_text}", "camera-retro", :text => "<script></script>"
   end
 
   test "#fa_icon should not html escape safe text" do
     icon = i("fa fa-camera-retro")
     icon_text = text("<script></script>", "fa-text fa-text-right")
-    assert_icon "#{icon}#{icon_text}", "camera-retro", :text => "<script></script>".html_safe
+    assert_icon "#{icon} #{icon_text}", "camera-retro", :text => "<script></script>".html_safe
   end
 
   test "#fa_icon should pull it all together" do
     icon = i("fa fa-camera-retro pull-right")
     icon_text = text("Take a photo", "fa-text fa-text-right")
-    assert_icon "#{icon}#{icon_text}", "camera-retro", :text => "Take a photo", :class => "pull-right"
+    assert_icon "#{icon} #{icon_text}", "camera-retro", :text => "Take a photo", :class => "pull-right"
   end
 
   test "#fa_icon should pass all other options through" do
@@ -91,19 +91,19 @@ class FontAwesome::Rails::IconHelperTest < ActionView::TestCase
 
   test "#fa_stacked_icon should be able to put the icon on the right" do
     icon_text = text("Go", "fa-text fa-text-left")
-    expected = %(#{icon_text}<span class="fa-stack">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-exclamation fa-stack-1x")}</span>)
+    expected = %(#{icon_text} <span class="fa-stack">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-exclamation fa-stack-1x")}</span>)
     assert_stacked_icon expected, "exclamation", :text => "Go", :right => true
   end
 
   test "#fa_stacked_icon should html escape text" do
     icon_text = text("&lt;script&gt;", "fa-text fa-text-right")
-    expected = %(<span class="fa-stack">#{i("fa fa-check-empty fa-stack-2x")}#{i("fa fa-twitter fa-stack-1x")}</span>#{icon_text})
+    expected = %(<span class="fa-stack">#{i("fa fa-check-empty fa-stack-2x")}#{i("fa fa-twitter fa-stack-1x")}</span> #{icon_text})
     assert_stacked_icon expected, "twitter", :base => "check-empty", :text => "<script>"
   end
 
   test "#fa_stacked_icon should not html escape safe text" do
     icon_text = text("<script>", "fa-text fa-text-right")
-    expected = %(<span class="fa-stack">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-twitter fa-stack-1x")}</span>#{icon_text})
+    expected = %(<span class="fa-stack">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-twitter fa-stack-1x")}</span> #{icon_text})
     assert_stacked_icon expected, "twitter", :base => "square-o", :text => "<script>".html_safe
   end
 

--- a/test/icon_helper_test.rb
+++ b/test/icon_helper_test.rb
@@ -34,23 +34,33 @@ class FontAwesome::Rails::IconHelperTest < ActionView::TestCase
   end
 
   test "#fa_icon should incorporate a text suffix" do
-    assert_icon "#{i("fa fa-camera-retro")} Take a photo", "camera-retro", :text => "Take a photo"
+    icon = i("fa fa-camera-retro")
+    icon_text = text("Take a photo", "fa-text fa-text-right")
+    assert_icon "#{icon}#{icon_text}", "camera-retro", :text => "Take a photo"
   end
 
   test "#fa_icon should be able to put the icon on the right" do
-    assert_icon "Submit #{i("fa fa-chevron-right")}", "chevron-right", :text => "Submit", :right => true
+    icon = i("fa fa-chevron-right")
+    icon_text = text("Submit", "fa-text fa-text-left")
+    assert_icon "#{icon_text}#{icon}", "chevron-right", :text => "Submit", :right => true
   end
 
   test "#fa_icon should html escape text" do
-    assert_icon "#{i("fa fa-camera-retro")} &lt;script&gt;&lt;/script&gt;", "camera-retro", :text => "<script></script>"
+    icon = i("fa fa-camera-retro")
+    icon_text = text("&lt;script&gt;&lt;/script&gt;", "fa-text fa-text-right")
+    assert_icon "#{icon}#{icon_text}", "camera-retro", :text => "<script></script>"
   end
 
   test "#fa_icon should not html escape safe text" do
-    assert_icon "#{i("fa fa-camera-retro")} <script></script>", "camera-retro", :text => "<script></script>".html_safe
+    icon = i("fa fa-camera-retro")
+    icon_text = text("<script></script>", "fa-text fa-text-right")
+    assert_icon "#{icon}#{icon_text}", "camera-retro", :text => "<script></script>".html_safe
   end
 
   test "#fa_icon should pull it all together" do
-    assert_icon "#{i("fa fa-camera-retro pull-right")} Take a photo", "camera-retro", :text => "Take a photo", :class => "pull-right"
+    icon = i("fa fa-camera-retro pull-right")
+    icon_text = text("Take a photo", "fa-text fa-text-right")
+    assert_icon "#{icon}#{icon_text}", "camera-retro", :text => "Take a photo", :class => "pull-right"
   end
 
   test "#fa_icon should pass all other options through" do
@@ -80,17 +90,20 @@ class FontAwesome::Rails::IconHelperTest < ActionView::TestCase
   end
 
   test "#fa_stacked_icon should be able to put the icon on the right" do
-    expected = %(Go <span class="fa-stack">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-exclamation fa-stack-1x")}</span>)
+    icon_text = text("Go", "fa-text fa-text-left")
+    expected = %(#{icon_text}<span class="fa-stack">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-exclamation fa-stack-1x")}</span>)
     assert_stacked_icon expected, "exclamation", :text => "Go", :right => true
   end
 
   test "#fa_stacked_icon should html escape text" do
-    expected = %(<span class="fa-stack">#{i("fa fa-check-empty fa-stack-2x")}#{i("fa fa-twitter fa-stack-1x")}</span> &lt;script&gt;)
+    icon_text = text("&lt;script&gt;", "fa-text fa-text-right")
+    expected = %(<span class="fa-stack">#{i("fa fa-check-empty fa-stack-2x")}#{i("fa fa-twitter fa-stack-1x")}</span>#{icon_text})
     assert_stacked_icon expected, "twitter", :base => "check-empty", :text => "<script>"
   end
 
   test "#fa_stacked_icon should not html escape safe text" do
-    expected = %(<span class="fa-stack">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-twitter fa-stack-1x")}</span> <script>)
+    icon_text = text("<script>", "fa-text fa-text-right")
+    expected = %(<span class="fa-stack">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-twitter fa-stack-1x")}</span>#{icon_text})
     assert_stacked_icon expected, "twitter", :base => "square-o", :text => "<script>".html_safe
   end
 
@@ -118,5 +131,9 @@ class FontAwesome::Rails::IconHelperTest < ActionView::TestCase
 
   def i(classes)
     %(<i class="#{classes}"></i>)
+  end
+
+  def text(text, classes)
+    %(<span class="#{classes}">#{text}</span>)
   end
 end


### PR DESCRIPTION
Instead of joining the text in a way that cannot be targeted with CSS, we can wrap it in a span so that we can target it and style it however one might want!

Examples from the updated README:

```ruby
fa_icon "camera-retro"
# => <i class="fa fa-camera-retro"></i>

fa_icon "camera-retro", text: "Take a photo"
# => <i class="fa fa-camera-retro"></i><span class="fa-text fa-text-right">Take a photo</span>

fa_icon "chevron-right", text: "Get started", right: true
# => <span class="fa-text fa-text-left">Get started</span><i class="fa fa-chevron-right"></i>

fa_icon "quote-left 4x", class: "text-muted pull-left"
# => <i class="fa fa-quote-left fa-4x text-muted pull-left"></i>

content_tag(:li, fa_icon("check li", text: "Bulleted list item"))
# => <li><i class="fa fa-check fa-li"></i><span class="fa-text fa-text-right">Bulleted list item</span></li>
```

```ruby
fa_stacked_icon "twitter", base: "square-o"
# => <span class="fa-stack">
# =>   <i class="fa fa-square-o fa-stack-2x"></i>
# =>   <i class="fa fa-twitter fa-stack-1x"></i>
# => </span>

fa_stacked_icon "terminal inverse", base: "square", class: "pull-right", text: "Hi!"
# => <span class="fa-stack pull-right">
# =>   <i class="fa fa-square fa-stack-2x"></i>
# =>   <i class="fa fa-terminal fa-inverse fa-stack-1x"></i>
# => </span><span class="fa-text fa-text-right">Hi!</span>
```

Now we can target the text for styling:

```scss
.fa-text {
  &.fa-text-right {
    margin-left: 1rem;
  }
  &.fa-text-left {
    margin-right: 1rem;
  }
}

.fa-chain + .fa-text {
  text-transform: uppercase;
}
```