### PR TITLE
Update README.md to clarify use of relative URL root

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ with every icon. Prepend the `fa` class to existing icons:
   <i class="fa fa-github"></i>
 ```
 
-**Note when deploying to sub-domains**
+**Note when deploying to sub-folders**
 It is sometimes the case that deploying a Rails application to a production
-environment requires the application to be hosted at a sub-domain on the server.
+environment requires the application to be hosted at a sub-folder on the server.
 This may be the case, for example, if Apache HTTPD or Nginx is being used as a
-front-end proxy server, with Rails handling only requests that come in to a sub-domain
-such as `http://myserver.example.com/myrailsapp`. In this case, the
-FontAwesome gem (and other asset-serving engines) needs to know the sub-domain,
+front-end proxy server, with Rails handling only requests that come in to a sub-folder
+such as `http://example.com/myrailsapp`. In this case, the
+FontAwesome gem (and other asset-serving engines) needs to know the sub-folder,
 otherwise you can experience a problem roughly described as ["my app works
 fine in development, but fails when I deploy
 it"](https://github.com/bokmann/font-awesome-rails/issues/74).


### PR DESCRIPTION
The use of 'sub-domain' is misleading, as the problem appears to be associated with the use of a sub-folder instead. 

To clarify, in the URL `http://www.example.com/path-to-app` the sub-domain is `www` and the sub-folder is `path-to-app`.