### PR TITLE
Fixes filter property for old IE versions.

### DIFF
--- a/app/assets/stylesheets/font-awesome.css.erb
+++ b/app/assets/stylesheets/font-awesome.css.erb
@@ -112,31 +112,31 @@
   }
 }
 .fa-rotate-90 {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
+  filter: progid\:DXImageTransform\.Microsoft\.BasicImage(rotation\=1);
   -webkit-transform: rotate(90deg);
   -ms-transform: rotate(90deg);
   transform: rotate(90deg);
 }
 .fa-rotate-180 {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
+  filter: progid\:DXImageTransform\.Microsoft\.BasicImage(rotation\=2);
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }
 .fa-rotate-270 {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
+  filter: progid\:DXImageTransform\.Microsoft\.BasicImage(rotation\=3);
   -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
   transform: rotate(270deg);
 }
 .fa-flip-horizontal {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1);
+  filter: progid\:DXImageTransform\.Microsoft\.BasicImage(rotation\=0, mirror\=1);
   -webkit-transform: scale(-1, 1);
   -ms-transform: scale(-1, 1);
   transform: scale(-1, 1);
 }
 .fa-flip-vertical {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1);
+  filter: progid\:DXImageTransform\.Microsoft\.BasicImage(rotation\=2, mirror\=1);
   -webkit-transform: scale(1, -1);
   -ms-transform: scale(1, -1);
   transform: scale(1, -1);


### PR DESCRIPTION
Actually I've just found out that the css part for the repo didn't include the fix from font-awesome: this avoids dreaded warnings on Safari.

You can read more about this kind of issue here:

https://github.com/FortAwesome/Font-Awesome/issues/5043

