### PR TITLE
Unable to require helper in other helper gem

### DIFF
--- a/font-awesome-rails.gemspec
+++ b/font-awesome-rails.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.files         = Dir["{app,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
   gem.test_files    = Dir["test/**/*"]
   gem.name          = "font-awesome-rails"
-  gem.require_paths = ["lib"]
+  gem.require_paths = ["lib", "app"]
   gem.version       = FontAwesome::Rails::VERSION
 
   gem.add_dependency "railties", ">= 3.2", "< 5.0"

--- a/lib/font-awesome-rails.rb
+++ b/lib/font-awesome-rails.rb
@@ -1,2 +1,3 @@
 require "font-awesome-rails/version"
 require "font-awesome-rails/engine" if defined?(::Rails)
+require "helpers/font_awesome/rails/icon_helper"


### PR DESCRIPTION
Hi,

I’m making a simple helper gem and I’m using `font-awesome-rails` to make the Font Awesome assets available in my project.

I now want to use the `fa_icon` helper, but I'm having issues including the helper in my custom helper using:

```ruby
class Builder
  include FontAwesome::Rails::IconHelper
  ...
end
```
It seems like the issue is related to the helper not being in the require path of the gem, thus not being required when I require the lib.

I’ve made a change here that requires the helper explicitly that fixes this issue in my case. Do you agree with this change? It shouldn’t create any issues I think.

Maybe you have a different solution?

Cheers,
Ole