### PR TITLE
Converted <i> tags to <span>

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,38 +52,38 @@ views _icontastic!_
 
 ```ruby
 fa_icon "camera-retro"
-# => <i class="fa fa-camera-retro"></i>
+# => <span class="fa fa-camera-retro"></span>
 
 fa_icon "camera-retro", text: "Take a photo"
-# => <i class="fa fa-camera-retro"></i> Take a photo
+# => <span class="fa fa-camera-retro"></span> Take a photo
 
 fa_icon "chevron-right", text: "Get started", right: true
-# => Get started <i class="fa fa-chevron-right"></i>
+# => Get started <span class="fa fa-chevron-right"></span>
 
 fa_icon "quote-left 4x", class: "text-muted pull-left"
-# => <i class="fa fa-quote-left fa-4x text-muted pull-left"></i>
+# => <span class="fa fa-quote-left fa-4x text-muted pull-left"></span>
 
 content_tag(:li, fa_icon("check li", text: "Bulleted list item"))
-# => <li><i class="fa fa-check fa-li"></i> Bulleted list item</li>
+# => <li><span class="fa fa-check fa-li"></span> Bulleted list item</li>
 ```
 
 ```ruby
 fa_stacked_icon "twitter", base: "square-o"
 # => <span class="fa-stack">
-# =>   <i class="fa fa-square-o fa-stack-2x"></i>
-# =>   <i class="fa fa-twitter fa-stack-1x"></i>
+# =>   <span class="fa fa-square-o fa-stack-2x"></span>
+# =>   <span class="fa fa-twitter fa-stack-1x"></span>
 # => </span>
 
 fa_stacked_icon "dollar inverse", base: "circle", class: "fa-5x"
 # => <span class="fa-stack fa-5x">
-# =>   <i class="fa fa-circle fa-stack-2x"></i>
-# =>   <i class="fa fa-dollar fa-inverse fa-stack-1x"></i>
+# =>   <span class="fa fa-circle fa-stack-2x"></span>
+# =>   <span class="fa fa-dollar fa-inverse fa-stack-1x"></span>
 # => </span>
 
 fa_stacked_icon "terminal inverse", base: "square", class: "pull-right", text: "Hi!"
 # => <span class="fa-stack pull-right">
-# =>   <i class="fa fa-square fa-stack-2x"></i>
-# =>   <i class="fa fa-terminal fa-inverse fa-stack-1x"></i>
+# =>   <span class="fa fa-square fa-stack-2x"></span>
+# =>   <span class="fa fa-terminal fa-inverse fa-stack-1x"></span>
 # => </span> Hi!
 
 ```

--- a/app/helpers/font_awesome/rails/icon_helper.rb
+++ b/app/helpers/font_awesome/rails/icon_helper.rb
@@ -7,35 +7,35 @@ module FontAwesome
       # Examples
       #
       #   fa_icon "camera-retro"
-      #   # => <i class="fa fa-camera-retro"></i>
+      #   # => <span class="fa fa-camera-retro"></span>
       #
       #   fa_icon "camera-retro", text: "Take a photo"
-      #   # => <i class="fa fa-camera-retro"></i> Take a photo
+      #   # => <span class="fa fa-camera-retro"></span> Take a photo
       #   fa_icon "chevron-right", text: "Get started", right: true
-      #   # => Get started <i class="fa fa-chevron-right"></i>
+      #   # => Get started <span class="fa fa-chevron-right"></span>
       #
       #   fa_icon "camera-retro 2x"
-      #   # => <i class="fa fa-camera-retro fa-2x"></i>
+      #   # => <span class="fa fa-camera-retro fa-2x"></span>
       #   fa_icon ["camera-retro", "4x"]
-      #   # => <i class="fa fa-camera-retro fa-4x"></i>
+      #   # => <span class="fa fa-camera-retro fa-4x"></span>
       #   fa_icon "spinner spin lg"
-      #   # => <i class="fa fa-spinner fa-spin fa-lg">
+      #   # => <span class="fa fa-spinner fa-spin fa-lg"></span>
       #
       #   fa_icon "quote-left 4x", class: "pull-left"
-      #   # => <i class="fa fa-quote-left fa-4x pull-left"></i>
+      #   # => <span class="fa fa-quote-left fa-4x pull-left"></span>
       #
       #   fa_icon "user", data: { id: 123 }
-      #   # => <i class="fa fa-user" data-id="123"></i>
+      #   # => <span class="fa fa-user" data-id="123"></span>
       #
       #   content_tag(:li, fa_icon("check li", text: "Bulleted list item"))
-      #   # => <li><i class="fa fa-check fa-li"></i> Bulleted list item</li>
+      #   # => <li><span class="fa fa-check fa-li"></span> Bulleted list item</li>
       def fa_icon(names = "flag", options = {})
         classes = ["fa"]
         classes.concat Private.icon_names(names)
         classes.concat Array(options.delete(:class))
         text = options.delete(:text)
         right_icon = options.delete(:right)
-        icon = content_tag(:i, nil, options.merge(:class => classes))
+        icon = content_tag(:span, nil, options.merge(:class => classes))
         Private.icon_join(icon, text, right_icon)
       end
 
@@ -46,20 +46,20 @@ module FontAwesome
       #
       #   fa_stacked_icon "twitter", base: "square-o"
       #   # => <span class="fa-stack">
-      #   # =>   <i class="fa fa-square-o fa-stack-2x"></i>
-      #   # =>   <i class="fa fa-twitter fa-stack-1x"></i>
+      #   # =>   <span class="fa fa-square-o fa-stack-2x"></span>
+      #   # =>   <span class="fa fa-twitter fa-stack-1x"></span>
       #   # => </span>
       #
       #   fa_stacked_icon "terminal inverse", base: "square", class: "pull-right", text: "Hi!"
       #   # => <span class="fa-stack pull-right">
-      #   # =>   <i class="fa fa-square fa-stack-2x"></i>
-      #   # =>   <i class="fa fa-terminal fa-inverse fa-stack-1x"></i>
+      #   # =>   <span class="fa fa-square fa-stack-2x"></span>
+      #   # =>   <span class="fa fa-terminal fa-inverse fa-stack-1x"></span>
       #   # => </span> Hi!
       #
       #   fa_stacked_icon "camera", base: "ban-circle", reverse: true
       #   # => <span class="fa-stack">
-      #   # =>   <i class="fa fa-camera fa-stack-1x"></i>
-      #   # =>   <i class="fa fa-ban-circle fa-stack-2x"></i>
+      #   # =>   <span class="fa fa-camera fa-stack-1x"></span>
+      #   # =>   <span class="fa fa-ban-circle fa-stack-2x"></span>
       #   # => </span>
       def fa_stacked_icon(names = "flag", options = {})
         classes = Private.icon_names("stack").concat(Array(options.delete(:class)))

--- a/test/font_awesome_rails_test.rb
+++ b/test/font_awesome_rails_test.rb
@@ -54,7 +54,7 @@ class FontAwesomeRailsTest < ActionDispatch::IntegrationTest
   test "helpers should be available in the view" do
     get "/icons"
     assert_response :success
-    assert_select "i.fa.fa-flag"
+    assert_select "span.fa.fa-flag"
     assert_select "span.fa-stack"
   end
 

--- a/test/icon_helper_test.rb
+++ b/test/icon_helper_test.rb
@@ -3,104 +3,104 @@ require 'test_helper'
 class FontAwesome::Rails::IconHelperTest < ActionView::TestCase
 
   test "#fa_icon with no args should render a flag icon" do
-    assert_icon i("fa fa-flag")
+    assert_icon span("fa fa-flag")
   end
 
   test "#fa_icon should render different individual icons" do
-    assert_icon i("fa fa-flag"),         "flag"
-    assert_icon i("fa fa-camera-retro"), "camera-retro"
-    assert_icon i("fa fa-cog"),          "cog"
-    assert_icon i("fa fa-github"),       "github"
+    assert_icon span("fa fa-flag"),         "flag"
+    assert_icon span("fa fa-camera-retro"), "camera-retro"
+    assert_icon span("fa fa-cog"),          "cog"
+    assert_icon span("fa fa-github"),       "github"
   end
 
   test "#fa_icon should render icons with multiple modifiers" do
-    assert_icon i("fa fa-pencil fa-fixed-width"), "pencil fixed-width"
-    assert_icon i("fa fa-flag fa-4x"),            "flag 4x"
-    assert_icon i("fa fa-refresh fa-2x fa-spin"), "refresh 2x spin"
+    assert_icon span("fa fa-pencil fa-fixed-width"), "pencil fixed-width"
+    assert_icon span("fa fa-flag fa-4x"),            "flag 4x"
+    assert_icon span("fa fa-refresh fa-2x fa-spin"), "refresh 2x spin"
   end
 
   test "#fa_icon should render icons with array modifiers" do
-    assert_icon i("fa fa-flag"),                  ["flag"]
-    assert_icon i("fa fa-check fa-li"),           ["check", "li"]
-    assert_icon i("fa fa-flag fa-4x"),            ["flag", "4x"]
-    assert_icon i("fa fa-refresh fa-2x fa-spin"), ["refresh", "2x", "spin"]
+    assert_icon span("fa fa-flag"),                  ["flag"]
+    assert_icon span("fa fa-check fa-li"),           ["check", "li"]
+    assert_icon span("fa fa-flag fa-4x"),            ["flag", "4x"]
+    assert_icon span("fa fa-refresh fa-2x fa-spin"), ["refresh", "2x", "spin"]
   end
 
   test "#fa_icon should incorporate additional class styles" do
-    assert_icon i("fa fa-flag pull-right"),                "flag",         :class => "pull-right"
-    assert_icon i("fa fa-flag fa-2x pull-right"),          ["flag", "2x"], :class => ["pull-right"]
-    assert_icon i("fa fa-check fa-li pull-right special"), "check li",     :class => "pull-right special"
-    assert_icon i("fa fa-check pull-right special"),       "check",        :class => ["pull-right", "special"]
+    assert_icon span("fa fa-flag pull-right"),                "flag",         :class => "pull-right"
+    assert_icon span("fa fa-flag fa-2x pull-right"),          ["flag", "2x"], :class => ["pull-right"]
+    assert_icon span("fa fa-check fa-li pull-right special"), "check li",     :class => "pull-right special"
+    assert_icon span("fa fa-check pull-right special"),       "check",        :class => ["pull-right", "special"]
   end
 
   test "#fa_icon should incorporate a text suffix" do
-    assert_icon "#{i("fa fa-camera-retro")} Take a photo", "camera-retro", :text => "Take a photo"
+    assert_icon "#{span("fa fa-camera-retro")} Take a photo", "camera-retro", :text => "Take a photo"
   end
 
   test "#fa_icon should be able to put the icon on the right" do
-    assert_icon "Submit #{i("fa fa-chevron-right")}", "chevron-right", :text => "Submit", :right => true
+    assert_icon "Submit #{span("fa fa-chevron-right")}", "chevron-right", :text => "Submit", :right => true
   end
 
   test "#fa_icon should html escape text" do
-    assert_icon "#{i("fa fa-camera-retro")} &lt;script&gt;&lt;/script&gt;", "camera-retro", :text => "<script></script>"
+    assert_icon "#{span("fa fa-camera-retro")} &lt;script&gt;&lt;/script&gt;", "camera-retro", :text => "<script></script>"
   end
 
   test "#fa_icon should not html escape safe text" do
-    assert_icon "#{i("fa fa-camera-retro")} <script></script>", "camera-retro", :text => "<script></script>".html_safe
+    assert_icon "#{span("fa fa-camera-retro")} <script></script>", "camera-retro", :text => "<script></script>".html_safe
   end
 
   test "#fa_icon should pull it all together" do
-    assert_icon "#{i("fa fa-camera-retro pull-right")} Take a photo", "camera-retro", :text => "Take a photo", :class => "pull-right"
+    assert_icon "#{span("fa fa-camera-retro pull-right")} Take a photo", "camera-retro", :text => "Take a photo", :class => "pull-right"
   end
 
   test "#fa_icon should pass all other options through" do
-    assert_icon %(<i class="fa fa-user" data-id="123"></i>), "user", :data => { :id => 123 }
+    assert_icon %(<span class="fa fa-user" data-id="123"></span>), "user", :data => { :id => 123 }
   end
 
   test "#fa_stacked_icon with no args should render a flag icon" do
-    expected = %(<span class="fa-stack">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-flag fa-stack-1x")}</span>)
+    expected = %(<span class="fa-stack">#{span("fa fa-square-o fa-stack-2x")}#{span("fa fa-flag fa-stack-1x")}</span>)
     assert_stacked_icon expected
   end
 
   test "#fa_stacked_icon should render a stacked icon" do
-    expected = %(<span class="fa-stack">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-twitter fa-stack-1x")}</span>)
+    expected = %(<span class="fa-stack">#{span("fa fa-square-o fa-stack-2x")}#{span("fa fa-twitter fa-stack-1x")}</span>)
     assert_stacked_icon expected, "twitter", :base => "square-o"
-    expected = %(<span class="fa-stack">#{i("fa fa-square fa-stack-2x")}#{i("fa fa-terminal fa-inverse fa-stack-1x")}</span>)
+    expected = %(<span class="fa-stack">#{span("fa fa-square fa-stack-2x")}#{span("fa fa-terminal fa-inverse fa-stack-1x")}</span>)
     assert_stacked_icon expected, ["terminal", "inverse"], :base => ["square"]
   end
 
   test "#fa_stacked_icon should incorporate additional class styles" do
-    expected = %(<span class="fa-stack pull-right">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-twitter fa-stack-1x")}</span>)
+    expected = %(<span class="fa-stack pull-right">#{span("fa fa-square-o fa-stack-2x")}#{span("fa fa-twitter fa-stack-1x")}</span>)
     assert_stacked_icon expected, "twitter", :base => "square-o", :class => "pull-right"
   end
 
   test "#fa_stacked_icon should reverse the stack" do
-    expected = %(<span class="fa-stack">#{i("fa fa-facebook fa-stack-1x")}#{i("fa fa-ban fa-stack-2x")}</span>)
+    expected = %(<span class="fa-stack">#{span("fa fa-facebook fa-stack-1x")}#{span("fa fa-ban fa-stack-2x")}</span>)
     assert_stacked_icon expected, "facebook", :base => "ban", :reverse => "true"
   end
 
   test "#fa_stacked_icon should be able to put the icon on the right" do
-    expected = %(Go <span class="fa-stack">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-exclamation fa-stack-1x")}</span>)
+    expected = %(Go <span class="fa-stack">#{span("fa fa-square-o fa-stack-2x")}#{span("fa fa-exclamation fa-stack-1x")}</span>)
     assert_stacked_icon expected, "exclamation", :text => "Go", :right => true
   end
 
   test "#fa_stacked_icon should html escape text" do
-    expected = %(<span class="fa-stack">#{i("fa fa-check-empty fa-stack-2x")}#{i("fa fa-twitter fa-stack-1x")}</span> &lt;script&gt;)
+    expected = %(<span class="fa-stack">#{span("fa fa-check-empty fa-stack-2x")}#{span("fa fa-twitter fa-stack-1x")}</span> &lt;script&gt;)
     assert_stacked_icon expected, "twitter", :base => "check-empty", :text => "<script>"
   end
 
   test "#fa_stacked_icon should not html escape safe text" do
-    expected = %(<span class="fa-stack">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-twitter fa-stack-1x")}</span> <script>)
+    expected = %(<span class="fa-stack">#{span("fa fa-square-o fa-stack-2x")}#{span("fa fa-twitter fa-stack-1x")}</span> <script>)
     assert_stacked_icon expected, "twitter", :base => "square-o", :text => "<script>".html_safe
   end
 
   test "#fa_stacked_icon should accept options for base and main icons" do
-    expected = %(<span class="fa-stack">#{i("fa fa-camera fa-stack-1x text-info")}#{i("fa fa-ban fa-stack-2x text-error")}</span>)
+    expected = %(<span class="fa-stack">#{span("fa fa-camera fa-stack-1x text-info")}#{span("fa fa-ban fa-stack-2x text-error")}</span>)
     assert_stacked_icon expected, "camera", :base => "ban", :reverse => true, :base_options => { :class => "text-error" }, :icon_options => { :class => "text-info" }
   end
 
   test "#fa_stacked_icon should pass all other options through" do
-    expected = %(<span class="fa-stack" data-id="123">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-user fa-stack-1x")}</span>)
+    expected = %(<span class="fa-stack" data-id="123">#{span("fa fa-square-o fa-stack-2x")}#{span("fa fa-user fa-stack-1x")}</span>)
     assert_stacked_icon expected, "user", :base => "square-o", :data => { :id => 123 }
   end
 
@@ -116,7 +116,7 @@ class FontAwesome::Rails::IconHelperTest < ActionView::TestCase
     assert_dom_equal expected, fa_stacked_icon(*args), message
   end
 
-  def i(classes)
-    %(<i class="#{classes}"></i>)
+  def span(classes)
+    %(<span class="#{classes}"></span>)
   end
 end


### PR DESCRIPTION
As per the HTML5 specification, using a `<span>` tag is the semantically correct way to display icons. Since the Font Awesome site says the only reason they prefer `<i>` tags is brevity, it probably makes sense to have the helper generate the semantically correct HTML ouput.

Source: https://fortawesome.github.io/Font-Awesome/examples/ (under "Basic Icons")