### PR TITLE
Raise railties dependency to be compatible with Rails 5

### DIFF
--- a/font-awesome-rails.gemspec
+++ b/font-awesome-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = FontAwesome::Rails::VERSION
 
-  gem.add_dependency "railties", ">= 3.2", "< 5.0"
+  gem.add_dependency "railties", ">= 3.2", "< 5.1"
 
   gem.add_development_dependency "activesupport"
   gem.add_development_dependency "sass-rails"


### PR DESCRIPTION
Raise the railties dependency to `'< 5.1'` to be compatible with the soon arriving Rails 5 release.

Signed-off-by: Clemens Gruber <clemensgru@gmail.com>