### PR TITLE
helpers should not modify passed options

### DIFF
--- a/app/helpers/font_awesome/rails/icon_helper.rb
+++ b/app/helpers/font_awesome/rails/icon_helper.rb
@@ -29,7 +29,8 @@ module FontAwesome
       #
       #   content_tag(:li, fa_icon("check li", text: "Bulleted list item"))
       #   # => <li><i class="fa fa-check fa-li"></i> Bulleted list item</li>
-      def fa_icon(names = "flag", options = {})
+      def fa_icon(names = "flag", original_options = {})
+        options = original_options.deep_dup
         classes = ["fa"]
         classes.concat Private.icon_names(names)
         classes.concat Array(options.delete(:class))
@@ -61,7 +62,8 @@ module FontAwesome
       #   # =>   <i class="fa fa-camera fa-stack-1x"></i>
       #   # =>   <i class="fa fa-ban-circle fa-stack-2x"></i>
       #   # => </span>
-      def fa_stacked_icon(names = "flag", options = {})
+      def fa_stacked_icon(names = "flag", original_options = {})
+        options = original_options.deep_dup
         classes = Private.icon_names("stack").concat(Array(options.delete(:class)))
         base_names = Private.array_value(options.delete(:base) || "square-o").push("stack-2x")
         names = Private.array_value(names).push("stack-1x")

--- a/test/icon_helper_test.rb
+++ b/test/icon_helper_test.rb
@@ -57,6 +57,14 @@ class FontAwesome::Rails::IconHelperTest < ActionView::TestCase
     assert_icon %(<i class="fa fa-user" data-id="123"></i>), "user", :data => { :id => 123 }
   end
 
+  test '#fa_icon does not modify options' do
+    icon_options = { :class => 'foo', :data => { :id => 123 }, :text => 'bar' }
+    assert_icon %(<i class="fa fa-user foo" data-id="123"></i> bar), "user", icon_options
+    assert_includes icon_options, :class
+    assert_includes icon_options, :text
+    assert_includes icon_options, :data
+  end
+
   test "#fa_stacked_icon with no args should render a flag icon" do
     expected = %(<span class="fa-stack">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-flag fa-stack-1x")}</span>)
     assert_stacked_icon expected
@@ -102,6 +110,14 @@ class FontAwesome::Rails::IconHelperTest < ActionView::TestCase
   test "#fa_stacked_icon should pass all other options through" do
     expected = %(<span class="fa-stack" data-id="123">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-user fa-stack-1x")}</span>)
     assert_stacked_icon expected, "user", :base => "square-o", :data => { :id => 123 }
+  end
+
+  test '#fa_stacked_icon does not modify options' do
+    icon_options = { :class => 'foo', :base => "square-o", :data => { :id => 123 } }
+    expected = %(<span class="fa-stack foo" data-id="123">#{i("fa fa-square-o fa-stack-2x")}#{i("fa fa-user fa-stack-1x")}</span>)
+    assert_stacked_icon expected, "user", icon_options
+    assert_includes icon_options, :class
+    assert_includes icon_options, :data
   end
 
   private


### PR DESCRIPTION
If you want to store options into a variable to avoid duplication,
unfortunately, the fa_icon changes the passed options. Therefore, the
second time that fa_icon is called with the same variable, some of
values are removed, e.g. class.

```slim
- icon_options = { class: 'foo' }
= fa_icon 'user', icon_options
= fa_icon 'tags', icon_options # this one will not have the foo class
```