### PR TITLE
convert underscores to dashes for allowing symbols

### DIFF
--- a/app/helpers/font_awesome/rails/icon_helper.rb
+++ b/app/helpers/font_awesome/rails/icon_helper.rb
@@ -86,7 +86,7 @@ module FontAwesome
         end
 
         def self.icon_names(names = [])
-          array_value(names).map { |n| "fa-#{n}" }
+          array_value(names).map { |n| "fa-#{n.to_s.gsub("_","-")}" }
         end
 
         def self.array_value(value = [])

--- a/test/icon_helper_test.rb
+++ b/test/icon_helper_test.rb
@@ -25,6 +25,11 @@ class FontAwesome::Rails::IconHelperTest < ActionView::TestCase
     assert_icon i("fa fa-flag fa-4x"),            ["flag", "4x"]
     assert_icon i("fa fa-refresh fa-2x fa-spin"), ["refresh", "2x", "spin"]
   end
+  test "#fa_icon should dasherize icon names" do
+    assert_icon i("fa fa-building-o"),                  ["building_o"]
+    assert_icon i("fa fa-building-o"),                  [:building_o]
+    assert_icon i("fa fa-building-o fixed_width"),      [:building_o, :fixed_width]
+  end
 
   test "#fa_icon should incorporate additional class styles" do
     assert_icon i("fa fa-flag pull-right"),                "flag",         :class => "pull-right"


### PR DESCRIPTION
I prefer the simplified syntax of `fa_icon :clock_o` vs `fa_icon 'clock-o'` so I've made it that we'll convert _'s to dashes