### PR TITLE
Replace gemspec description with something more 'sensible'

### DIFF
--- a/font-awesome-rails.gemspec
+++ b/font-awesome-rails.gemspec
@@ -4,7 +4,7 @@ require File.expand_path('../lib/font-awesome-rails/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.authors       = ["bokmann"]
   gem.email         = ["dbock@codesherpas.com"]
-  gem.description   = "I like font-awesome. I like the asset pipeline. I like semantic versioning. If you do too, you're welcome."
+  gem.description   = "font-awesome-rails provides the Font-Awesome web fonts and stylesheets as a Rails engine for use with the asset pipeline."
   gem.summary       = "an asset gemification of the font-awesome icon font library"
   gem.homepage      = "https://github.com/bokmann/font-awesome-rails"
   gem.licenses      = ["MIT", "SIL Open Font License"]


### PR DESCRIPTION
We want to use this gem in openSUSE Tumbleweed/Kubic/SUSE Linux Enterprise.
Our distributions feel it is important to provide sensible, clear explanations to users regarding the function and purpose of a package.

We map gem's description field to rpm's description field, which is satisfactory for 99.99% of the gems we have in our distribution, but font-awesome-rails' somewhat frivolous gem.description runs counter to our needs.

Therefore this PR replaces the gem.description with the perfectly clear and sensible equivalent from the projects README

Please consider this change so we don't need to carry quirky patches for the gem in our distributions :)

Regards,

Richard Brown
openSUSE