### PR TITLE
Add Rails 6.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,27 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.3.5
-  - 2.4.3
-  - 2.5.0
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
 gemfile:
   - Gemfile
   - gemfiles/rails-4.2.gemfile
   - gemfiles/rails-5.0.gemfile
   - gemfiles/rails-5.1.gemfile
   - gemfiles/rails-5.2.gemfile
+  - gemfiles/rails-6.0.gemfile
   - gemfiles/rails-master.gemfile
 matrix:
   include:
     - rvm: 2.2.9
       gemfile: gemfiles/rails-3.2.gemfile
+  exclude:
+    - rvm: 2.3.8
+      gemfile: gemfiles/rails-6.0.gemfile
+    - rvm: 2.4.6
+      gemfile: gemfiles/rails-6.0.gemfile
   allow_failures:
-    - rvm: 2.5.0
     - gemfile: gemfiles/rails-master.gemfile
   fast_finish: true

--- a/font-awesome-rails.gemspec
+++ b/font-awesome-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = FontAwesome::Rails::VERSION
 
-  gem.add_dependency "railties", ">= 3.2", "< 6.0"
+  gem.add_dependency "railties", ">= 3.2", "< 6.1"
 
   gem.add_development_dependency "activesupport"
   gem.add_development_dependency "sass-rails"

--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gemspec path: "../"
+gem "railties", ">= 6.0.0.beta3", "< 6.1"


### PR DESCRIPTION
This PR should allow Rails 6.0 to be used with. 

It is currently testing against `6.0.0.beta3` on Travis CI. Since Rails 6.0.0 is probably released during RailsConf 2019 which starts on April 30th, I think that beta3 won't be much different from official release of 6.0.0.