### PR TITLE
Remove sass-rails in favor of sassc-rails

### DIFF
--- a/font-awesome-rails.gemspec
+++ b/font-awesome-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "railties", ">= 3.2", "< 6.1"
 
   gem.add_development_dependency "activesupport"
-  gem.add_development_dependency "sass-rails"
+  gem.add_development_dependency "sassc-rails"
 
   gem.required_ruby_version = '>= 1.9.3'
 end

--- a/test/dummy/config/initializers/secret_token.rb
+++ b/test/dummy/config/initializers/secret_token.rb
@@ -6,10 +6,17 @@
 # no regular words or you'll be exposed to dictionary attacks.
 #
 # avoid deprecation warnings if building against older versions of Rails
-SKB_VERSION = Gem::Version.new('4.0.0')
-RG_VERSION = Rails.respond_to?(:version) ? Gem::Version.new(Rails.version) : Gem::Version.new('3.22')
 
-if RG_VERSION < SKB_VERSION 
+# secret_token migrated to secret_key_base in Rails 4
+SKB_VERSION = Gem::Version.new('4.0.0')
+
+# Get the current Rails version.
+RAILS_VERSION = Rails.respond_to?(:version) ? Gem::Version.new(Rails.version) : Gem::Version.new('3.22')
+
+# if we're running an old version of Rails
+if RAILS_VERSION < SKB_VERSION 
   Dummy::Application.config.secret_token    = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+else
+  Dummy::Application.config.secret_key_base = 'deadbeef' if Dummy::Application.config.respond_to?(:secret_key_base)
 end 
-Dummy::Application.config.secret_key_base = 'deadbeef' if Dummy::Application.config.respond_to?(:secret_key_base)
+

--- a/test/dummy/config/initializers/secret_token.rb
+++ b/test/dummy/config/initializers/secret_token.rb
@@ -4,5 +4,12 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Dummy::Application.config.secret_token    = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+#
+# avoid deprecation warnings if building against older versions of Rails
+SKB_VERSION = Gem::Version.new('4.0.0')
+RG_VERSION = Rails.respond_to?(:version) ? Gem::Version.new(Rails.version) : Gem::Version.new('3.22')
+
+if RG_VERSION < SKB_VERSION 
+  Dummy::Application.config.secret_token    = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+end 
 Dummy::Application.config.secret_key_base = 'deadbeef' if Dummy::Application.config.respond_to?(:secret_key_base)


### PR DESCRIPTION
Fixes #203 -- sass gem is now deprecated.
Heads off warnings about deprecation of `secret_token` if Rails version > 4.