### PR TITLE
Add font-display: block to font face declaration

### DIFF
--- a/app/assets/stylesheets/font-awesome.css.erb
+++ b/app/assets/stylesheets/font-awesome.css.erb
@@ -15,6 +15,7 @@
   src: url('<%= font_path('fontawesome-webfont.eot') %>?#iefix') format('embedded-opentype'), url('<%= font_path('fontawesome-webfont.woff2') %>') format('woff2'), url('<%= font_path('fontawesome-webfont.woff') %>') format('woff'), url('<%= font_path('fontawesome-webfont.ttf') %>') format('truetype'), url('<%= font_path('fontawesome-webfont.svg') %>#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
+  font-display: block;
 }
 .fa {
   display: inline-block;


### PR DESCRIPTION
Lighthouse is warning about it and
some browsers would use incorrect behaviour (swap) if `auto` or nothing provided
Issue on FA:
https://github.com/FortAwesome/Font-Awesome/issues/16077

Change already scheduled for FA 5.12.2
https://github.com/FortAwesome/Font-Awesome/issues/16077#issuecomment-594581049