### PR TITLE
Bump version for Rails 6.1 release

### DIFF
--- a/lib/font-awesome-rails/version.rb
+++ b/lib/font-awesome-rails/version.rb
@@ -1,6 +1,6 @@
 module FontAwesome
   module Rails
     FA_VERSION = "4.7.0"
-    VERSION = "4.7.0.5"
+    VERSION = "4.7.0.6"
   end
 end


### PR DESCRIPTION
Latest published version of `font-awesome-rails` (`4.7.0.5`) has dependencies:

```rb
railties >= 3.2, < 6.1
```

Looks like the 6.1 release has already been accommodated for in https://github.com/bokmann/font-awesome-rails/commit/d4a2e506be0318e35d05ad22d36531b7da393615. Bumping the patch version should resolve https://github.com/bokmann/font-awesome-rails/issues/206.