### PR TITLE
Update README.md — an old version is missing an upward bound in the gemspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ In addition you need to indicate the subfolder when you *precompile* the assets:
 **Note:** In Rails 3.2, make sure font-awesome-rails is outside the bundler asset group
 so that these helpers are automatically loaded in production environments.
 
+
+### Rails 4+ Apps — Watch out Not To get stuck on Version 3.1.1.0 
+You will note specifically 3.1.1.0 accidentally is missing an upward bound on its Rails version in the gem dependancy. Because of this, you may inadvertentlly stay on that old gem version not even knowing it. To fix, specify a version using a soft specifier ( like ~> ) in your `Gemfile` to coorespond with the one for your Rails version. After you pass version 3.1.1.0 of this gem in your Rails app, you *should not* need to keep doing this (you can remove the soft specifier in your `Gemfile`) because the Gemspec will manage which version is appropriate for you. This will apply to any new Rails app too because it will pick up the 3.1.1.0 version until you fix the problem. 
+
+
+### Rails 6.1 
+Specifically, upgrading to Rails 6.1 while on version 3.1.1.0 of font-awesome-rails (see above) breaks all the fonts. Don't get frustrated by attempting to bundle update font-awesome-raills, or set its version number to anything below 4.7.0.6 — because all the intermediate versions are correctly 'version-locked' to Rails's version.
+
+Version 4.7.0.6 fixes the issue for your Rails 6.1 app.
+
 ## Versioning
 
 Versioning follows the core releases of Font-Awesome which follows Semantic


### PR DESCRIPTION
adds explanation about getting stuck on Version 3.1.1.0

@bokmann — I would recommend you *yank* 3.1.1.0 to fix this problem. 

if you strongly want to support Rails 3.1 with changes in that gem release, you can make a 3.1.1.0b, with fixed gemspec that has upward bounds.

the reason it's a problem is that everytime someone creates a new Rails app (using `rails new`) bundler picks 3.1.1.0 because it thinks it is compatible with every Rails version, so this pitfall will happen on all new Rails apps. 

my explanation is a stop-gap and can be removed if/when you yank the un-bounded gem version from Rubygems. 