### PR TITLE
Make compatible with Rails 7

### DIFF
--- a/font-awesome-rails.gemspec
+++ b/font-awesome-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = FontAwesome::Rails::VERSION
 
-  gem.add_dependency "railties", ">= 3.2", "< 7"
+  gem.add_dependency "railties", ">= 3.2", "< 7.1"
 
   gem.add_development_dependency "activesupport"
   gem.add_development_dependency "sassc-rails"


### PR DESCRIPTION
Simple update to the gemspec file, to make font-awesome-rails compatible with Rails 7, released December 15, 2021.

Fixes #224