### PR TITLE
Update Font Awesome url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Gem Downloads](https://img.shields.io/gem/dt/font-awesome-rails.svg)](https://rubygems.org/gems/font-awesome-rails)
 
 font-awesome-rails provides the
-[Font-Awesome](http://fortawesome.github.com/Font-Awesome/) web fonts and
+[Font-Awesome](http://fortawesome.github.io/Font-Awesome/) web fonts and
 stylesheets as a Rails engine for use with the asset pipeline.
 
 ## Installation


### PR DESCRIPTION
I noticed that the README has a (now-broken) reference to http://fortawesome.github.com/Font-Awesome which I believe should be updated to http://fortawesome.github.io/Font-Awesome as referenced further down in the document.