### PR TITLE
Docs: Add more examples for stacked_icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ fa_stacked_icon "terminal inverse", base: "square", class: "pull-right", text: "
 # =>   <i class="fa fa-terminal fa-inverse fa-stack-1x"></i>
 # => </span> Hi!
 
+fa_stacked_icon "camera", base: "ban", base_options: { style: "color:Tomato" }
+# => <span class="fa-stack">
+# =>   <i class="fa fa-ban fa-stack-2x" style="color:Tomato"></i>
+# =>   <i class="fa fa-camera fa-stack-1x"></i>
+# => </span>
+
+fa_stacked_icon "flag", base: "circle", icon_options: { style: "color:Green" }
+# => <span class="fa-stack">
+# =>   <i class="fa fa-circle fa-stack-2x"></i>
+# =>   <i class="fa fa-flag fa-stack-1x" style="color:Green"></i>
+# => </span>
 ```
 
 ## Misc

--- a/app/helpers/font_awesome/rails/icon_helper.rb
+++ b/app/helpers/font_awesome/rails/icon_helper.rb
@@ -62,6 +62,18 @@ module FontAwesome
       #   # =>   <i class="fa fa-camera fa-stack-1x"></i>
       #   # =>   <i class="fa fa-ban-circle fa-stack-2x"></i>
       #   # => </span>
+      #
+      #   fa_stacked_icon "camera", base: "ban", base_options: { style: "color:Tomato" }
+      #   # => <span class="fa-stack">
+      #   # =>   <i class="fa fa-ban fa-stack-2x" style="color:Tomato"></i>
+      #   # =>   <i class="fa fa-camera fa-stack-1x"></i>
+      #   # => </span>
+      #
+      #   fa_stacked_icon "flag", base: "circle", icon_options: { style: "color:Green" }
+      #   # => <span class="fa-stack">
+      #   # =>   <i class="fa fa-circle fa-stack-2x"></i>
+      #   # =>   <i class="fa fa-flag fa-stack-1x" style="color:Green"></i>
+      #   # => </span>
       def fa_stacked_icon(names = "flag", original_options = {})
         options = original_options.deep_dup
         classes = Private.icon_names("stack").concat(Array(options.delete(:class)))


### PR DESCRIPTION
Docs: Add more examples for stacked_icon

- Add an example for the usage of `base_options`
- Add an example for the usage of `icon_options`