### PR TITLE
docs: update font awesome official urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Gem Downloads](https://img.shields.io/gem/dt/font-awesome-rails.svg)](https://rubygems.org/gems/font-awesome-rails)
 
 font-awesome-rails provides the
-[Font-Awesome](http://fortawesome.github.io/Font-Awesome/) web fonts and
+[Font-Awesome](https://fontawesome.com) web fonts and
 stylesheets as a Rails engine for use with the asset pipeline.
 
 ## Installation
@@ -30,7 +30,7 @@ In your `application.css`, include the css file:
 Then restart your webserver if it was previously running.
 
 Congrats! You now have scalable vector icon support. Pick an icon and check out the
-[FontAwesome Examples](http://fortawesome.github.io/Font-Awesome/examples/).
+[FontAwesome Examples](https://fontawesome.com/icons).
 
 ### Sass Support
 
@@ -147,9 +147,9 @@ make any breaking changes until Font-Awesome core makes a major version bump.
 
 ## License
 
-* The [Font Awesome](http://fortawesome.github.io/Font-Awesome) font is
+* The [Font Awesome](https://fontawesome.com) font is
   licensed under the [SIL Open Font License](http://scripts.sil.org/OFL).
-* [Font Awesome](http://fortawesome.github.io/Font-Awesome) CSS files are
+* [Font Awesome](https://fontawesome.com) CSS files are
   licensed under the
   [MIT License](http://opensource.org/licenses/mit-license.html).
 * The remainder of the font-awesome-rails project is licensed under the


### PR DESCRIPTION
https://fortawesome.github.com/Font-Awesome is no longer available as a github page

https://fontawesome.com should be the right link for newer versions
https://fontawesome.com/v4/examples also exists for old versions

The main url of this repo should be also updated
<img width="375" alt="image" src="https://user-images.githubusercontent.com/83595831/171739509-19459cd0-c295-4153-a550-cd141c24bd43.png">
